### PR TITLE
feat: Add Team feature with CRUD endpoints

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -46,6 +46,7 @@ model User {
 
   accounts Account[]
   sessions Session[]
+  teams    Team[]
 
   @@map("users")
 }
@@ -117,4 +118,16 @@ model Verification {
 
   @@unique([identifier, value])
   @@map("verifications")
+}
+
+model Team {
+  id          String   @id @default(uuid())
+  title       String
+  description String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+  userId      String   @map("user_id")
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("teams")
 }

--- a/backend/src/controllers/team.controller.ts
+++ b/backend/src/controllers/team.controller.ts
@@ -1,0 +1,81 @@
+import httpStatus from "http-status";
+import asyncHandler from "express-async-handler";
+import ApiError from "../utils/ApiError";
+import teamService from "../services/team.service";
+import { getUserFromReq } from "better-auth/src/helpers";
+
+const createTeam = asyncHandler(async (req, res) => {
+  const user = await getUserFromReq(req);
+  if (!user) {
+    throw new ApiError(httpStatus.UNAUTHORIZED, "User not found");
+  }
+  const team = await teamService.createTeam(user.id, req.body);
+  res.status(httpStatus.CREATED).send(team);
+});
+
+const getTeams = asyncHandler(async (req, res) => {
+  const user = await getUserFromReq(req);
+  if (!user) {
+    throw new ApiError(httpStatus.UNAUTHORIZED, "User not found");
+  }
+  const options = {
+    sortBy: req.query.sortBy as string,
+    limit: req.query.limit ? parseInt(req.query.limit as string) : 20,
+    page: req.query.page ? parseInt(req.query.page as string) : 1,
+    sortType: req.query.sortType as "asc" | "desc",
+  };
+
+  const teams = await teamService.queryTeams({ userId: user.id }, options);
+
+  res.send(teams);
+});
+
+const getTeam = asyncHandler(async (req, res) => {
+  const user = await getUserFromReq(req);
+  if (!user) {
+    throw new ApiError(httpStatus.UNAUTHORIZED, "User not found");
+  }
+  const teamId = req.params.id;
+  const team = await teamService.getTeamById(teamId);
+
+  if (!team) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Team not found");
+  }
+
+  if (team.userId !== user.id) {
+    throw new ApiError(httpStatus.FORBIDDEN, "Forbidden");
+  }
+  res.send(team);
+});
+
+const updateTeam = asyncHandler(async (req, res) => {
+  const user = await getUserFromReq(req);
+  if (!user) {
+    throw new ApiError(httpStatus.UNAUTHORIZED, "User not found");
+  }
+  const teamId = req.params.id;
+  const team = await teamService.updateTeamById(
+    teamId,
+    user.id,
+    req.body
+  );
+  res.send(team);
+});
+
+const deleteTeam = asyncHandler(async (req, res) => {
+  const user = await getUserFromReq(req);
+  if (!user) {
+    throw new ApiError(httpStatus.UNAUTHORIZED, "User not found");
+  }
+  const teamId = req.params.id;
+  await teamService.deleteTeamById(teamId, user.id);
+  res.status(httpStatus.NO_CONTENT).send();
+});
+
+export default {
+  createTeam,
+  getTeams,
+  getTeam,
+  updateTeam,
+  deleteTeam,
+};

--- a/backend/src/docs/components.yml
+++ b/backend/src/docs/components.yml
@@ -19,6 +19,24 @@ components:
         createdAt: 2020-05-12T16:18:04.793Z
         updatedAt: 2020-05-12T16:18:04.793Z
 
+    Team:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        userId:
+          type: string
+      example:
+        id: 2650f8ef-8419-4ea6-9614-a8ea7bb1b093
+        title: My Awesome Team
+        description: This is a description of my awesome team.
+        userId: clrqy6svo000012mjd9wgc1p0
+        createdAt: 2020-05-12T16:18:04.793Z
+        updatedAt: 2020-05-12T16:18:04.793Z
 
     Payout:
       type: object

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,12 +1,14 @@
 import express from "express";
 import payoutRoutes from "./payout.routes";
 import campaignRoutes from "./campaign.routes";
+import teamRoutes from "./team.routes";
 import docRoute from "../docs/swagger";
 
 const router = express.Router();
 
 router.use("/payouts", payoutRoutes);
 router.use("/campaigns", campaignRoutes);
+router.use("/teams", teamRoutes);
 router.use("/docs", docRoute);
 
 export default router;

--- a/backend/src/routes/team.routes.ts
+++ b/backend/src/routes/team.routes.ts
@@ -1,0 +1,212 @@
+import express from "express";
+import validate from "../middlewares/validate";
+import teamValidation from "../validations/team.validation";
+import teamController from "../controllers/team.controller";
+import { requireUser } from "better-auth/src/middlewares";
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Team
+ *   description: Team management
+ */
+
+/**
+ * @swagger
+ * /teams:
+ *   post:
+ *     summary: Create a team
+ *     description: Create a new team for the logged-in user.
+ *     tags: [Team]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *             properties:
+ *               title:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *             example:
+ *               title: My New Team
+ *               description: This is a description of my new team.
+ *     responses:
+ *       "201":
+ *         description: Created
+ *         content:
+ *           application/json:
+ *             schema:
+ *                $ref: '#/components/schemas/Team'
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ */
+router
+    .route("/")
+    .post(
+        requireUser,
+        validate(teamValidation.createTeam),
+        teamController.createTeam
+    )
+    /**
+     * @swagger
+     * /teams:
+     *   get:
+     *     summary: Get all teams for the current user
+     *     description: Retrieve all teams for the logged-in user
+     *     tags: [Team]
+     *     security:
+     *       - bearerAuth: []
+     *     parameters:
+     *       - in: query
+     *         name: sortBy
+     *         schema:
+     *           type: string
+     *         description: sort by query in the form of field:desc/asc (ex. name:asc)
+     *       - in: query
+     *         name: limit
+     *         schema:
+     *           type: integer
+     *           minimum: 1
+     *         default: 10
+     *         description: Maximum number of teams
+     *       - in: query
+     *         name: page
+     *         schema:
+     *           type: integer
+     *           minimum: 1
+     *           default: 1
+     *         description: Page number
+     *     responses:
+     *       "200":
+     *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 results:
+     *                   type: array
+     *                   items:
+     *                     $ref: '#/components/schemas/Team'
+     *       "401":
+     *         $ref: '#/components/responses/Unauthorized'
+     */
+    .get(requireUser, validate(teamValidation.getTeams), teamController.getTeams);
+
+/**
+ * @swagger
+ * /teams/{id}:
+ *   get:
+ *     summary: Get a team by id
+ *     description: Get a team by its id.
+ *     tags: [Team]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Team id
+ *     responses:
+ *       "200":
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *                $ref: '#/components/schemas/Team'
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ *       "404":
+ *         $ref: '#/components/responses/NotFound'
+ */
+router
+    .route("/:id")
+    .get(requireUser, validate(teamValidation.getTeam), teamController.getTeam)
+    /**
+     * @swagger
+     * /teams/{id}:
+     *   patch:
+     *     summary: Update a team
+     *     description: Update a team by its id.
+     *     tags: [Team]
+     *     security:
+     *       - bearerAuth: []
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: Team id
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             type: object
+     *             properties:
+     *               title:
+     *                 type: string
+     *               description:
+     *                 type: string
+     *             example:
+     *               title: My Updated Team
+     *               description: This is the updated description.
+     *     responses:
+     *       "200":
+     *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *                $ref: '#/components/schemas/Team'
+     *       "401":
+     *         $ref: '#/components/responses/Unauthorized'
+     *       "404":
+     *         $ref: '#/components/responses/NotFound'
+     */
+    .patch(
+        requireUser,
+        validate(teamValidation.updateTeam),
+        teamController.updateTeam
+    )
+    /**
+     * @swagger
+     * /teams/{id}:
+     *   delete:
+     *     summary: Delete a team
+     *     description: Delete a team by its id.
+     *     tags: [Team]
+     *     security:
+     *       - bearerAuth: []
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: Team id
+     *     responses:
+     *       "204":
+     *         description: No content
+     *       "401":
+     *         $ref: '#/components/responses/Unauthorized'
+     *       "404":
+     *         $ref: '#/components/responses/NotFound'
+     */
+    .delete(
+        requireUser,
+        validate(teamValidation.deleteTeam),
+        teamController.deleteTeam
+    );
+
+export default router;

--- a/backend/src/services/team.service.ts
+++ b/backend/src/services/team.service.ts
@@ -1,0 +1,81 @@
+import { Team, Prisma } from "@prisma/client";
+import httpStatus from "http-status";
+import ApiError from "../utils/ApiError";
+import prisma from "../config/prisma";
+
+async function createTeam(userId: string, teamBody: { title: string, description?: string }): Promise<Team> {
+  return prisma.team.create({
+    data: {
+      ...teamBody,
+      user: {
+        connect: {
+          id: userId,
+        },
+      },
+    },
+  });
+}
+
+async function queryTeams(
+  filter: object,
+  options: {
+    limit: number;
+    page: number;
+    sortBy?: string;
+    sortType?: "asc" | "desc";
+  }
+) {
+  const { limit, page, sortBy, sortType } = options;
+
+  return prisma.team.paginate(
+    {
+      ...(!!filter && { where: filter }),
+      orderBy: sortBy ? { [sortBy]: sortType } : undefined,
+    },
+    { limit, page }
+  );
+}
+
+async function getTeamById(id: string) {
+  return prisma.team.findFirst({
+    where: { id },
+  });
+}
+
+async function updateTeamById(
+  id: string,
+  userId: string,
+  updateBody: Prisma.TeamUpdateInput
+): Promise<Team> {
+  const team = await getTeamById(id);
+  if (!team) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Team not found");
+  }
+  if (team.userId !== userId) {
+    throw new ApiError(httpStatus.FORBIDDEN, "Forbidden");
+  }
+  return prisma.team.update({
+    where: { id },
+    data: updateBody,
+  });
+}
+
+async function deleteTeamById(id: string, userId: string): Promise<Team> {
+  const team = await getTeamById(id);
+  if (!team) {
+    throw new ApiError(httpStatus.NOT_FOUND, "Team not found");
+  }
+  if (team.userId !== userId) {
+    throw new ApiError(httpStatus.FORBIDDEN, "Forbidden");
+  }
+  await prisma.team.delete({ where: { id: team.id } });
+  return team;
+}
+
+export default {
+  createTeam,
+  queryTeams,
+  getTeamById,
+  updateTeamById,
+  deleteTeamById,
+};

--- a/backend/src/validations/team.validation.ts
+++ b/backend/src/validations/team.validation.ts
@@ -1,0 +1,48 @@
+import Joi from "joi";
+
+const createTeam = {
+  body: Joi.object().keys({
+    title: Joi.string().required(),
+    description: Joi.string(),
+  }),
+};
+
+const getTeams = {
+  query: Joi.object().keys({
+    sortBy: Joi.string(),
+    limit: Joi.number().integer(),
+    page: Joi.number().integer(),
+  }),
+};
+
+const getTeam = {
+  params: Joi.object().keys({
+    id: Joi.string(),
+  }),
+};
+
+const updateTeam = {
+  params: Joi.object().keys({
+    id: Joi.string(),
+  }),
+  body: Joi.object()
+    .keys({
+      title: Joi.string(),
+      description: Joi.string(),
+    })
+    .min(1),
+};
+
+const deleteTeam = {
+  params: Joi.object().keys({
+    id: Joi.string(),
+  }),
+};
+
+export default {
+  createTeam,
+  getTeams,
+  getTeam,
+  updateTeam,
+  deleteTeam,
+};


### PR DESCRIPTION
This commit introduces a new `Team` feature to the backend, including a `Team` model, CRUD endpoints, controllers, services, and Swagger documentation.

The new `Team` model is defined in the Prisma schema and includes `id`, `title`, `description`, and a relationship to the `User` model.

The CRUD endpoints for the `Team` feature are implemented with proper validation and authorization checks. The `userId` is retrieved from the user's session to ensure that users can only access and modify their own teams.

The Swagger documentation has been updated to include the new `Team` schema and endpoints.